### PR TITLE
Adding multiple release architectures to Package Release github action

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -10,11 +10,32 @@ jobs:
     strategy:
       matrix:
         platform:
-          - filename: cpu
+          - filename: cpu-win64
             os: windows-latest
             requirements: cpu.txt
-          - filename: cuda
+          - filename: cuda-win64
             os: windows-latest
+            requirements: cuda.txt
+
+          - filename: cpu-macos-arm
+            os: macos-latest
+            requirements: cpu.txt
+          - filename: cuda-macos-arm
+            os: macos-latest
+            requirements: cuda.txt
+
+          - filename: cpu-macos-x86
+            os: macos-13
+            requirements: cpu.txt
+          - filename: cuda-macos-x86
+            os: macos-13
+            requirements: cuda.txt
+
+          - filename: cpu-linux
+            os: ubuntu-latest
+            requirements: cpu.txt
+          - filename: cuda-linux
+            os: ubuntu-latest
             requirements: cuda.txt
     runs-on: ${{ matrix.platform.os }}
     steps:
@@ -34,7 +55,7 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: "python -m pip install -r requirements/${{ matrix.platform.requirements }} --only-binary=llama_cpp_python --no-cache-dir --target .python_dependencies"
+        run: "python -m pip install -r requirements/${{ matrix.platform.requirements }} --no-cache-dir --target .python_dependencies"
         working-directory: meshgen
       
       - name: Archive release

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -1,4 +1,3 @@
---extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
 llama_cpp_python==0.2.90
 
 huggingface_hub

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,4 +1,3 @@
---extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu121
 llama_cpp_python==0.2.90
 
 huggingface_hub


### PR DESCRIPTION
This commit adds functionality in the `package-release.yml` file to build this blender extension with multiple architectures. I personally was unable to use the provided release zip on linux with the same issues outlined in #14, it seems that the library `llama_cpp_python` needs to be compiled with the right architecture in mind. 

Tested by using below sample run on Linux and Windows (I don't have machines to test macos-arm and macos-intel so if anyone does please give that a shot)

Sample run from this commit cherry-picked on top of `releases/0.3.0`
https://github.com/zosman1/meshgen/actions/runs/12267123439 



Resolves #14
