### PR TITLE
feat: Enable llama-cpp-python metal backend for Apple devices

### DIFF
--- a/operators/install_dependencies.py
+++ b/operators/install_dependencies.py
@@ -106,6 +106,8 @@ def install_and_load_dependencies():
 
     if (sys.platform == "win32" or sys.platform == "linux") and check_cuda():
         requirements_file = absolute_path("./requirements/cuda.txt")
+    elif sys.platform == "darwin":
+        requirements_file = absolute_path("./requirements/metal.txt")
     else:
         requirements_file = absolute_path("./requirements/cpu.txt")
     

--- a/requirements/metal.txt
+++ b/requirements/metal.txt
@@ -1,0 +1,5 @@
+--extra-index-url https://abetlen.github.io/llama-cpp-python/whl/metal
+llama_cpp_python==0.3.5
+
+huggingface_hub
+ollama


### PR DESCRIPTION
## High Level Description
Adds metal backend through latest llama-cpp-python release 0.3.5 through a specific requirements file

n.b. The current cpu whls on macOS seem to utilise the GPU regardless of lack of specific metal version install.

## Problem:
Current installation for Apple devices specifies generic build rather than metal backend.

## Solution:
Install latest compatible metal distribution of [llama-cpp-python](https://abetlen.github.io/llama-cpp-python/whl/metal/llama-cpp-python/). Also works with the following:
* `0.3.0`
* `0.3.1`
* `0.3.2`

`0.2.90` fails with:
```
>>> rm -rf ~/Library/Application Support/Blender/4.3/scripts/addons/meshgen/.python_dependencies/ && /Applications/Blender.app/Contents/Resources/4.3/python/bin/python3.11 -m pip install -r requirements/metal.txt --upgrade --no-cache-dir --target .python_dependencies

ERROR: Exception:
Traceback (most recent call last):
  File "/Applications/Blender.app/Contents/Resources/4.3/python/lib/python3.11/site-packages/pip/_internal/cli/base_command.py", line 105, in _run_wrapper
    status = _inner_run()
             ^^^^^^^^^^^^
  File "/Applications/Blender.app/Contents/Resources/4.3/python/lib/python3.11/site-packages/pip/_internal/cli/base_command.py", line 96, in _inner_run
    return self.run(options, args)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Applications/Blender.app/Contents/Resources/4.3/python/lib/python3.11/site-packages/pip/_internal/cli/req_command.py", line 67, in wrapper
    return func(self, options, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Applications/Blender.app/Contents/Resources/4.3/python/lib/python3.11/site-packages/pip/_internal/commands/install.py", line 457, in run
    installed = install_given_reqs(
                ^^^^^^^^^^^^^^^^^^^
  File "/Applications/Blender.app/Contents/Resources/4.3/python/lib/python3.11/site-packages/pip/_internal/req/__init__.py", line 70, in install_given_reqs
    requirement.install(
  File "/Applications/Blender.app/Contents/Resources/4.3/python/lib/python3.11/site-packages/pip/_internal/req/req_install.py", line 867, in install
    install_wheel(
  File "/Applications/Blender.app/Contents/Resources/4.3/python/lib/python3.11/site-packages/pip/_internal/operations/install/wheel.py", line 732, in install_wheel
    _install_wheel(
  File "/Applications/Blender.app/Contents/Resources/4.3/python/lib/python3.11/site-packages/pip/_internal/operations/install/wheel.py", line 590, in _install_wheel
    file.save()
  File "/Applications/Blender.app/Contents/Resources/4.3/python/lib/python3.11/site-packages/pip/_internal/operations/install/wheel.py", line 380, in save
    shutil.copyfileobj(f, dest, blocksize)
  File "/Applications/Blender.app/Contents/Resources/4.3/python/lib/python3.11/shutil.py", line 197, in copyfileobj
    buf = fsrc_read(length)
          ^^^^^^^^^^^^^^^^^
  File "/Applications/Blender.app/Contents/Resources/4.3/python/lib/python3.11/zipfile.py", line 965, in read
    data = self._read1(n)
           ^^^^^^^^^^^^^^
  File "/Applications/Blender.app/Contents/Resources/4.3/python/lib/python3.11/zipfile.py", line 1055, in _read1
    self._update_crc(data)
  File "/Applications/Blender.app/Contents/Resources/4.3/python/lib/python3.11/zipfile.py", line 983, in _update_crc
    raise BadZipFile("Bad CRC-32 for file %r" % self.name)
zipfile.BadZipFile: Bad CRC-32 for file 'bin/llama-llava-cli'
```

`0.3.4` fails with:
```
ERROR: could not read 'llama_cpp_python-0.3.4.dist-info/METADATA' file: BadZipFile('Bad magic number for file header')
```
## Unlocks:
Possible future optimisations specific to utilising metal builds in macOS systems.