### PR TITLE
Update to new extension system

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,15 +1,3 @@
-bl_info = {
-    "name": "MeshGen",
-    "description": "A Blender addon for generating meshes with AI",
-    "author": "Hugging Face",
-    "version": (0, 3, 1),
-    "blender": (4, 1, 0),
-    "category": "Mesh",
-    "support": "COMMUNITY",
-    "update_url": "https://github.com/huggingface/meshgen",
-}
-
-
 import bpy
 
 from .operators import *

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,0 +1,24 @@
+schema_version = "1.0.0"
+
+id = "meshgen"
+version = "0.4.0"
+name = "meshgen"
+tagline = "A Blender addon for generating meshes with AI"
+maintainer = "Hugging Face"
+type = "add-on"
+
+website = "https://github.com/huggingface/meshgen"
+tags = ["mesh", "ai", "generative", "3d"]
+
+blender_version_min = "4.2.0"
+
+license = [
+    "MIT",
+]
+copyright = [
+    "2024- Hugging Face",
+]
+
+[permissions]
+network = "Download required models and dependencies"
+files = "Install required models and dependencies"

--- a/preferences.py
+++ b/preferences.py
@@ -23,14 +23,12 @@ class MeshGenPreferences(bpy.types.AddonPreferences):
             layout.label(text="Dependencies not installed.", icon="ERROR")
             box = layout.box()
             box.operator(MESHGEN_OT_InstallDependencies.bl_idname, icon="IMPORT")
-            #return
         else:
             layout.label(text="Dependencies installed.")
 
         if not generator.has_required_models():
             layout.label(text="Required models not downloaded.", icon="ERROR")
             layout.operator(MESHGEN_OT_DownloadRequiredModels.bl_idname, icon="IMPORT")
-            #return
         else:        
             layout.label(text="Ready to generate. Press 'N' -> MeshGen to get started.")
         
@@ -40,7 +38,9 @@ class MeshGenPreferences(bpy.types.AddonPreferences):
 
         if context.scene.meshgen_props.show_developer_options:
             box = layout.box()
-            box.operator(MESHGEN_OT_UninstallDependencies.bl_idname, icon="IMPORT")
+
+            if has_dependencies:
+                box.operator(MESHGEN_OT_UninstallDependencies.bl_idname, icon="IMPORT")
         
             if bpy.app.online_access:
                 box.prop(context.scene.meshgen_props, "use_ollama_backend", text="Use Ollama Backend")


### PR DESCRIPTION
Migrates from legacy add-ons to [Blender extensions](https://docs.blender.org/manual/en/latest/advanced/extensions/index.html), the system from Blender 4.2+